### PR TITLE
Fix critical errors

### DIFF
--- a/example1.js
+++ b/example1.js
@@ -1,5 +1,5 @@
 var mapnik = require('mapnik');
-var mapnikify = require('geojson-mapnikify');
+var mapnikify = require('@mapbox/geojson-mapnikify');
 var fs = require('fs');
 
 var width = 512;
@@ -25,7 +25,7 @@ mapnikify(geojson, false, function(err, xml){
         if (err) throw err;
         im.encode('png', function(err,buffer) {
             if (err) throw err;
-            fs.writeFile(,buffer, function(err) {
+            fs.writeFile(outputFilename, buffer, function(err) {
                 if (err) throw err;
                 console.log('saved map image to '+outputFilename);
             });
@@ -33,4 +33,3 @@ mapnikify(geojson, false, function(err, xml){
       });
   });
 });
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "",
   "dependencies": {
-    "geojson-mapnikify": "~0.4.3",
-    "mapnik": "~3.1.6"
+    "@mapbox/geojson-mapnikify": "^0.8.0",
+    "mapnik": "^3.6.2"
   }
 }


### PR DESCRIPTION
This fixes:
- `npm install` failing: `geojson-mapnikify` was renamed to `@mapbox/geojson-mapnikify`
- `example1.js` crashing: the first argument (`outputFilename`) was missing in `fs.writeFile()`